### PR TITLE
Add Writing pages, series filter, and home recent widget

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,7 +13,9 @@ const t = useTranslations(lang);
 
 const homePath = localizedPath('/', lang);
 const aboutPath = localizedPath('/about', lang);
+const writingPath = localizedPath('/writing', lang);
 const contactHref = currentPath === homePath ? '#contact' : `${homePath}#contact`;
+const isWritingActive = currentPath === writingPath || currentPath.startsWith(`${writingPath}/`);
 
 const otherLang: Lang = lang === 'en' ? 'ko' : 'en';
 const toggleHref = altLangPath ?? (otherLang === 'ko' ? '/ko/' : '/');
@@ -34,6 +36,7 @@ const toggleLabel = otherLang === 'ko' ? 'KO' : 'EN';
       <ul class="nav-links" id="nav-menu">
         <li><a href={homePath}>{t('nav.home')}</a></li>
         <li><a href={aboutPath} class={currentPath === aboutPath ? 'active' : ''} aria-current={currentPath === aboutPath ? 'page' : undefined}>{t('nav.about')}</a></li>
+        <li><a href={writingPath} class={isWritingActive ? 'active' : ''} aria-current={isWritingActive ? 'page' : undefined}>{t('nav.writing')}</a></li>
         <li><a href={contactHref}>{t('nav.contact')}</a></li>
       </ul>
       <a href={toggleHref} class="lang-toggle">{toggleLabel}</a>

--- a/src/components/WritingCard.astro
+++ b/src/components/WritingCard.astro
@@ -1,0 +1,95 @@
+---
+import type { WritingEntry } from '~/lib/collections';
+import type { Lang } from '~/i18n/ui';
+
+interface Props {
+  entry: WritingEntry;
+  lang: Lang;
+}
+
+const { entry, lang } = Astro.props;
+const slug = entry.slug.split('/').pop()!;
+const href = lang === 'en' ? `/writing/${slug}` : `/ko/writing/${slug}`;
+const dateLabel = entry.data.date.toLocaleDateString(lang === 'ko' ? 'ko-KR' : 'en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+const sourceLabel =
+  entry.data.source === 'brunch' ? 'Brunch' :
+  entry.data.source === 'nia' ? 'NIA' :
+  entry.data.source === 'dbr' ? 'DBR' :
+  entry.data.source === 'linkedin' ? 'LinkedIn' : null;
+---
+<article class="writing-card">
+  <a href={href} class="writing-card-link">
+    <div class="writing-card-meta">
+      <time datetime={entry.data.date.toISOString()}>{dateLabel}</time>
+      {sourceLabel && <span class="writing-card-source">{sourceLabel}</span>}
+      {entry.data.series && <span class="writing-card-series">{entry.data.series}</span>}
+    </div>
+    <h3 class="writing-card-title">{entry.data.title}</h3>
+    <p class="writing-card-summary">{entry.data.summary}</p>
+    {entry.data.tags.length > 0 && (
+      <div class="writing-card-tags">
+        {entry.data.tags.map((t) => <span class="writing-card-tag">#{t}</span>)}
+      </div>
+    )}
+  </a>
+</article>
+
+<style>
+  .writing-card {
+    border-top: 1px solid var(--color-border);
+    padding: 24px 0;
+  }
+  .writing-card-link {
+    display: block;
+    color: inherit;
+    text-decoration: none;
+  }
+  .writing-card-link:hover .writing-card-title {
+    color: var(--color-accent);
+  }
+  .writing-card-meta {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    font-size: 0.8125rem;
+    color: var(--color-muted);
+    margin-bottom: 8px;
+  }
+  .writing-card-source,
+  .writing-card-series {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: var(--color-border);
+    color: var(--color-muted);
+    font-weight: 500;
+  }
+  .writing-card-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0 0 8px;
+    line-height: 1.4;
+    transition: color 0.15s ease;
+  }
+  .writing-card-summary {
+    font-size: 0.9375rem;
+    color: var(--color-muted);
+    line-height: 1.6;
+    margin: 0 0 12px;
+  }
+  .writing-card-tags {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .writing-card-tag {
+    font-size: 0.75rem;
+    color: var(--color-accent);
+    font-weight: 400;
+  }
+</style>

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,0 +1,50 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+import type { Lang } from '~/i18n/ui';
+
+export type WritingEntry = CollectionEntry<'writing'>;
+
+/** Published entries (draft=false) in one language, newest first. */
+export async function getPublishedWriting(lang: Lang): Promise<WritingEntry[]> {
+  const all = await getCollection('writing', (e) => !e.data.draft && e.data.lang === lang);
+  return all.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}
+
+/** Entries in a given series, newest first. */
+export async function getWritingBySeries(series: string, lang: Lang): Promise<WritingEntry[]> {
+  const all = await getCollection(
+    'writing',
+    (e) => !e.data.draft && e.data.lang === lang && e.data.series === series,
+  );
+  return all.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}
+
+/** Entries matching a tag, newest first. */
+export async function getWritingByTag(tag: string, lang: Lang): Promise<WritingEntry[]> {
+  const all = await getCollection(
+    'writing',
+    (e) => !e.data.draft && e.data.lang === lang && e.data.tags.includes(tag),
+  );
+  return all.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}
+
+/** All distinct series that have at least one published entry. */
+export async function getActiveSeries(lang: Lang): Promise<string[]> {
+  const entries = await getPublishedWriting(lang);
+  const set = new Set<string>();
+  for (const e of entries) if (e.data.series) set.add(e.data.series);
+  return Array.from(set).sort();
+}
+
+/** All distinct tags. */
+export async function getActiveTags(lang: Lang): Promise<string[]> {
+  const entries = await getPublishedWriting(lang);
+  const set = new Set<string>();
+  for (const e of entries) for (const t of e.data.tags) set.add(t);
+  return Array.from(set).sort();
+}
+
+/** Most recent N entries, any series. */
+export async function getRecentWriting(n: number, lang: Lang): Promise<WritingEntry[]> {
+  const all = await getPublishedWriting(lang);
+  return all.slice(0, n);
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,11 @@
 ---
 import Base from '~/layouts/Base.astro';
+import { getRecentWriting } from '~/lib/collections';
+
+const recent = await getRecentWriting(3, 'en');
+const recentFallback = recent.length === 0 ? await getRecentWriting(3, 'ko') : [];
+const recentEntries = recent.length > 0 ? recent : recentFallback;
+const recentLang = recent.length > 0 ? 'en' : 'ko';
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -31,6 +37,20 @@ const jsonLd = {
   altLangPath="/ko/"
 >
   <style slot="head" is:inline>
+    .recent-writing { padding: 48px 0; border-top: 1px solid var(--color-border); }
+    .recent-writing-header { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 20px; }
+    .recent-writing-header h2 { margin: 0; font-size: 1.25rem; }
+    .recent-writing-all { font-size: 0.875rem; color: var(--color-muted); text-decoration: none; }
+    .recent-writing-all:hover { color: var(--color-accent); }
+    .recent-writing-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 2px; }
+    .recent-writing-list a {
+      display: flex; justify-content: space-between; align-items: baseline; gap: 16px;
+      padding: 12px 0; color: var(--color-text); text-decoration: none;
+      border-bottom: 1px solid var(--color-border);
+    }
+    .recent-writing-list a:hover .recent-writing-title { color: var(--color-accent); }
+    .recent-writing-title { font-size: 0.9375rem; font-weight: 500; flex: 1; }
+    .recent-writing-date { font-size: 0.8125rem; color: var(--color-muted); flex-shrink: 0; }
     .highlights-grid { display: flex; flex-direction: column; gap: 14px; }
     .highlight-card { text-align: center; }
     .highlight-text { font-size: 0.9375rem; font-weight: 500; color: var(--color-text); line-height: 1.5; }
@@ -102,6 +122,32 @@ const jsonLd = {
         </div>
       </section>
     </div>
+
+    {recentEntries.length > 0 && (
+      <section class="recent-writing">
+        <div class="container">
+          <div class="recent-writing-header">
+            <h2>Recent Writing</h2>
+            <a href={recentLang === 'ko' ? '/ko/writing' : '/writing'} class="recent-writing-all">All writing →</a>
+          </div>
+          <ul class="recent-writing-list">
+            {recentEntries.map((entry) => {
+              const slug = entry.slug.split('/').pop()!;
+              const href = recentLang === 'ko' ? `/ko/writing/${slug}` : `/writing/${slug}`;
+              const d = entry.data.date.toLocaleDateString(recentLang === 'ko' ? 'ko-KR' : 'en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+              return (
+                <li>
+                  <a href={href}>
+                    <span class="recent-writing-title">{entry.data.title}</span>
+                    <span class="recent-writing-date">{d}</span>
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </section>
+    )}
 
     <section id="founder" class="about-section">
       <div class="about-inner">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -1,5 +1,8 @@
 ---
 import Base from '~/layouts/Base.astro';
+import { getRecentWriting } from '~/lib/collections';
+
+const recentEntries = await getRecentWriting(3, 'ko');
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -36,6 +39,20 @@ const jsonLd = {
       word-break: keep-all;
       overflow-wrap: break-word;
     }
+    .recent-writing { padding: 48px 0; border-top: 1px solid var(--color-border); }
+    .recent-writing-header { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 20px; }
+    .recent-writing-header h2 { margin: 0; font-size: 1.25rem; }
+    .recent-writing-all { font-size: 0.875rem; color: var(--color-muted); text-decoration: none; }
+    .recent-writing-all:hover { color: var(--color-accent); }
+    .recent-writing-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 2px; }
+    .recent-writing-list a {
+      display: flex; justify-content: space-between; align-items: baseline; gap: 16px;
+      padding: 12px 0; color: var(--color-text); text-decoration: none;
+      border-bottom: 1px solid var(--color-border);
+    }
+    .recent-writing-list a:hover .recent-writing-title { color: var(--color-accent); }
+    .recent-writing-title { font-size: 0.9375rem; font-weight: 500; flex: 1; }
+    .recent-writing-date { font-size: 0.8125rem; color: var(--color-muted); flex-shrink: 0; }
     .connecting-item { letter-spacing: -0.01em; }
     .hero-vision { font-style: normal; }
     .highlights-grid { display: flex; flex-direction: column; gap: 14px; }
@@ -100,6 +117,31 @@ const jsonLd = {
         </div>
       </section>
     </div>
+
+    {recentEntries.length > 0 && (
+      <section class="recent-writing">
+        <div class="container">
+          <div class="recent-writing-header">
+            <h2>최근 글</h2>
+            <a href="/ko/writing" class="recent-writing-all">전체 보기 →</a>
+          </div>
+          <ul class="recent-writing-list">
+            {recentEntries.map((entry) => {
+              const slug = entry.slug.split('/').pop()!;
+              const d = entry.data.date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric' });
+              return (
+                <li>
+                  <a href={`/ko/writing/${slug}`}>
+                    <span class="recent-writing-title">{entry.data.title}</span>
+                    <span class="recent-writing-date">{d}</span>
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </section>
+    )}
 
     <section id="founder" class="about-section">
       <div class="about-inner">

--- a/src/pages/ko/writing/[slug]/index.astro
+++ b/src/pages/ko/writing/[slug]/index.astro
@@ -1,0 +1,156 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '~/layouts/Base.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('writing', (e) => !e.data.draft && e.data.lang === 'ko');
+  return entries.map((entry) => {
+    const slug = entry.slug.split('/').pop()!;
+    return { params: { slug }, props: { entry } };
+  });
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+const dateLabel = entry.data.date.toLocaleDateString('ko-KR', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+const sourceLabel =
+  entry.data.source === 'brunch' ? 'Brunch' :
+  entry.data.source === 'nia' ? 'NIA' :
+  entry.data.source === 'dbr' ? 'DBR' :
+  entry.data.source === 'linkedin' ? 'LinkedIn' : null;
+---
+<Base
+  title={`${entry.data.title} — 정채상`}
+  description={entry.data.summary}
+  lang="ko"
+  path={`/ko/writing/${entry.slug}`}
+  ogType="article"
+  altLangPath={`/writing/${entry.slug}`}
+>
+  <style slot="head" is:inline>
+    body {
+      font-family: 'Inter', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, sans-serif;
+      word-break: keep-all;
+      overflow-wrap: break-word;
+    }
+  </style>
+  <main>
+    <article class="writing-article">
+      <div class="writing-article-inner">
+        <nav class="writing-breadcrumb">
+          <a href="/ko/writing">← 글 목록</a>
+        </nav>
+
+        <header class="writing-article-header">
+          <div class="writing-article-meta">
+            <time datetime={entry.data.date.toISOString()}>{dateLabel}</time>
+            {sourceLabel && <span class="writing-article-source">{sourceLabel}</span>}
+            {entry.data.series && (
+              <a class="writing-article-series" href={`/ko/writing/series/${entry.data.series}`}>
+                {entry.data.series}
+              </a>
+            )}
+          </div>
+          <h1 class="writing-article-title">{entry.data.title}</h1>
+        </header>
+
+        <div class="prose">
+          <Content />
+        </div>
+
+        {entry.data.externalUrl && (
+          <aside class="writing-article-external">
+            <p>원문 ({sourceLabel || '외부'}):</p>
+            <a href={entry.data.externalUrl} target="_blank" rel="noopener noreferrer">
+              {entry.data.externalUrl}
+            </a>
+          </aside>
+        )}
+      </div>
+    </article>
+  </main>
+</Base>
+
+<style>
+  .writing-article { padding: 48px 0 80px; }
+  .writing-article-inner { max-width: 720px; margin: 0 auto; padding: 0 24px; }
+  .writing-breadcrumb { margin-bottom: 24px; font-size: 0.875rem; }
+  .writing-breadcrumb a { color: var(--color-muted); text-decoration: none; }
+  .writing-breadcrumb a:hover { color: var(--color-accent); }
+  .writing-article-header {
+    margin-bottom: 40px;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 24px;
+  }
+  .writing-article-meta {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    font-size: 0.8125rem;
+    color: var(--color-muted);
+    margin-bottom: 16px;
+  }
+  .writing-article-source,
+  .writing-article-series {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: var(--color-border);
+    color: var(--color-muted);
+    font-weight: 500;
+    text-decoration: none;
+  }
+  .writing-article-series:hover { color: var(--color-accent); }
+  .writing-article-title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px;
+    line-height: 1.3;
+  }
+  .writing-article-summary {
+    font-size: 1.0625rem;
+    color: var(--color-muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+  .prose { font-size: 1rem; line-height: 1.9; color: var(--color-text); }
+  .prose :global(h2) { font-size: 1.375rem; font-weight: 600; margin: 40px 0 16px; }
+  .prose :global(h3) { font-size: 1.125rem; font-weight: 600; margin: 32px 0 12px; }
+  .prose :global(p) { margin: 0 0 16px; }
+  .prose :global(a) { color: var(--color-accent); text-decoration: underline; }
+  .prose :global(img) { max-width: 100%; height: auto; border-radius: 4px; margin: 16px 0; }
+  .prose :global(blockquote) {
+    border-left: 3px solid var(--color-accent);
+    padding-left: 16px;
+    color: var(--color-muted);
+    font-style: italic;
+    margin: 24px 0;
+  }
+  .prose :global(code) {
+    background: var(--color-border);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.9em;
+  }
+  .prose :global(pre) {
+    background: var(--color-border);
+    padding: 16px;
+    border-radius: 4px;
+    overflow-x: auto;
+  }
+  .prose :global(ul), .prose :global(ol) { padding-left: 24px; margin: 0 0 16px; }
+  .prose :global(hr) { border: none; border-top: 1px solid var(--color-border); margin: 32px 0; }
+  .writing-article-external {
+    margin-top: 48px;
+    padding: 20px;
+    background: var(--color-border);
+    border-radius: 6px;
+    font-size: 0.875rem;
+  }
+  .writing-article-external p { margin: 0 0 6px; color: var(--color-muted); }
+  .writing-article-external a { color: var(--color-accent); word-break: break-all; }
+</style>

--- a/src/pages/ko/writing/index.astro
+++ b/src/pages/ko/writing/index.astro
@@ -1,0 +1,69 @@
+---
+import Base from '~/layouts/Base.astro';
+import WritingCard from '~/components/WritingCard.astro';
+import { getPublishedWriting } from '~/lib/collections';
+
+const entries = await getPublishedWriting('ko');
+---
+<Base
+  title="글 — 정채상 | 이음 테크"
+  description="미국과 한국을 오가며 일한 30년의 현장에서 눈에 들어온 것들을 짧게 적은 글 모음. 서비스, 조직, 그리고 반복해서 듣는 단어들."
+  lang="ko"
+  path="/ko/writing"
+  ogType="website"
+  altLangPath="/writing"
+>
+  <style slot="head" is:inline>
+    body {
+      font-family: 'Inter', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, sans-serif;
+      word-break: keep-all;
+      overflow-wrap: break-word;
+    }
+  </style>
+  <main>
+    <section class="writing-hero">
+      <div class="container">
+        <h1>글</h1>
+        <p class="writing-lead">
+          서비스 하나, 조직 하나, 그리고 한국 IT 현장에서 반복해서 듣는 단어 하나 —
+          그때그때 눈에 들어온 것들을 메모처럼 적어 둡니다. 대부분 Brunch에 먼저 올렸던 글입니다.
+        </p>
+      </div>
+    </section>
+
+    <section class="writing-list">
+      <div class="container">
+        {entries.length === 0 ? (
+          <p class="writing-empty">글이 아직 없습니다.</p>
+        ) : (
+          entries.map((entry) => <WritingCard entry={entry} lang="ko" />)
+        )}
+      </div>
+    </section>
+  </main>
+</Base>
+
+<style>
+  .writing-hero {
+    padding: 64px 0 32px;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .writing-hero h1 {
+    font-size: 2.25rem;
+    margin: 0 0 12px;
+  }
+  .writing-lead {
+    font-size: 1rem;
+    color: var(--color-muted);
+    line-height: 1.7;
+    max-width: 640px;
+  }
+  .writing-list {
+    padding: 32px 0 80px;
+  }
+  .writing-empty {
+    color: var(--color-muted);
+    padding: 32px 0;
+    text-align: center;
+  }
+</style>

--- a/src/pages/ko/writing/series/[slug]/index.astro
+++ b/src/pages/ko/writing/series/[slug]/index.astro
@@ -1,0 +1,74 @@
+---
+import Base from '~/layouts/Base.astro';
+import WritingCard from '~/components/WritingCard.astro';
+import { getActiveSeries, getWritingBySeries } from '~/lib/collections';
+
+export async function getStaticPaths() {
+  const series = await getActiveSeries('ko');
+  return series.map((slug) => ({ params: { slug } }));
+}
+
+const { slug } = Astro.params;
+const entries = await getWritingBySeries(slug!, 'ko');
+---
+<Base
+  title={`${slug} — 글 — 정채상`}
+  description={`시리즈: ${slug}`}
+  lang="ko"
+  path={`/ko/writing/series/${slug}`}
+  ogType="website"
+  altLangPath={`/writing/series/${slug}`}
+>
+  <style slot="head" is:inline>
+    body {
+      font-family: 'Inter', 'Noto Sans KR', -apple-system, BlinkMacSystemFont, sans-serif;
+      word-break: keep-all;
+      overflow-wrap: break-word;
+    }
+  </style>
+  <main>
+    <section class="writing-hero">
+      <div class="container">
+        <nav class="writing-breadcrumb">
+          <a href="/ko/writing">← 글 목록</a>
+        </nav>
+        <p class="writing-eyebrow">시리즈</p>
+        <h1>{slug}</h1>
+        <p class="writing-count">{entries.length}편</p>
+      </div>
+    </section>
+
+    <section class="writing-list">
+      <div class="container">
+        {entries.length === 0 ? (
+          <p class="writing-empty">이 시리즈에 글이 없습니다.</p>
+        ) : (
+          entries.map((entry) => <WritingCard entry={entry} lang="ko" />)
+        )}
+      </div>
+    </section>
+  </main>
+</Base>
+
+<style>
+  .writing-hero { padding: 64px 0 32px; border-bottom: 1px solid var(--color-border); }
+  .writing-breadcrumb { margin-bottom: 16px; font-size: 0.875rem; }
+  .writing-breadcrumb a { color: var(--color-muted); text-decoration: none; }
+  .writing-breadcrumb a:hover { color: var(--color-accent); }
+  .writing-eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-accent);
+    margin: 0 0 6px;
+    font-weight: 600;
+  }
+  .writing-hero h1 {
+    font-size: 2rem;
+    margin: 0 0 8px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .writing-count { font-size: 0.875rem; color: var(--color-muted); margin: 0; }
+  .writing-list { padding: 32px 0 80px; }
+  .writing-empty { color: var(--color-muted); padding: 32px 0; text-align: center; }
+</style>

--- a/src/pages/writing/[slug]/index.astro
+++ b/src/pages/writing/[slug]/index.astro
@@ -1,0 +1,191 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '~/layouts/Base.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('writing', (e) => !e.data.draft && e.data.lang === 'en');
+  return entries.map((entry) => {
+    const slug = entry.slug.split('/').pop()!;
+    return { params: { slug }, props: { entry } };
+  });
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+const dateLabel = entry.data.date.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+const sourceLabel =
+  entry.data.source === 'brunch' ? 'Brunch' :
+  entry.data.source === 'nia' ? 'NIA' :
+  entry.data.source === 'dbr' ? 'DBR' :
+  entry.data.source === 'linkedin' ? 'LinkedIn' : null;
+---
+<Base
+  title={`${entry.data.title} — Chaesang Jung`}
+  description={entry.data.summary}
+  lang="en"
+  path={`/writing/${entry.slug}`}
+  ogType="article"
+  altLangPath={`/ko/writing/${entry.slug}`}
+>
+  <main>
+    <article class="writing-article">
+      <div class="writing-article-inner">
+        <nav class="writing-breadcrumb">
+          <a href="/writing">← Writing</a>
+        </nav>
+
+        <header class="writing-article-header">
+          <div class="writing-article-meta">
+            <time datetime={entry.data.date.toISOString()}>{dateLabel}</time>
+            {sourceLabel && <span class="writing-article-source">{sourceLabel}</span>}
+            {entry.data.series && (
+              <a class="writing-article-series" href={`/writing/series/${entry.data.series}`}>
+                {entry.data.series}
+              </a>
+            )}
+          </div>
+          <h1 class="writing-article-title">{entry.data.title}</h1>
+        </header>
+
+        <div class="prose">
+          <Content />
+        </div>
+
+        {entry.data.externalUrl && (
+          <aside class="writing-article-external">
+            <p>Originally published on {sourceLabel || 'external site'}:</p>
+            <a href={entry.data.externalUrl} target="_blank" rel="noopener noreferrer">
+              {entry.data.externalUrl}
+            </a>
+          </aside>
+        )}
+      </div>
+    </article>
+  </main>
+</Base>
+
+<style>
+  .writing-article {
+    padding: 48px 0 80px;
+  }
+  .writing-article-inner {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+  .writing-breadcrumb {
+    margin-bottom: 24px;
+    font-size: 0.875rem;
+  }
+  .writing-breadcrumb a {
+    color: var(--color-muted);
+    text-decoration: none;
+  }
+  .writing-breadcrumb a:hover { color: var(--color-accent); }
+  .writing-article-header {
+    margin-bottom: 40px;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 24px;
+  }
+  .writing-article-meta {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    font-size: 0.8125rem;
+    color: var(--color-muted);
+    margin-bottom: 16px;
+  }
+  .writing-article-source,
+  .writing-article-series {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: var(--color-border);
+    color: var(--color-muted);
+    font-weight: 500;
+    text-decoration: none;
+  }
+  .writing-article-series:hover { color: var(--color-accent); }
+  .writing-article-title {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 12px;
+    line-height: 1.3;
+  }
+  .writing-article-summary {
+    font-size: 1.0625rem;
+    color: var(--color-muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+  .prose {
+    font-size: 1rem;
+    line-height: 1.8;
+    color: var(--color-text);
+  }
+  .prose :global(h2) {
+    font-size: 1.375rem;
+    font-weight: 600;
+    margin: 40px 0 16px;
+  }
+  .prose :global(h3) {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 32px 0 12px;
+  }
+  .prose :global(p) { margin: 0 0 16px; }
+  .prose :global(a) { color: var(--color-accent); text-decoration: underline; }
+  .prose :global(img) {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+    margin: 16px 0;
+  }
+  .prose :global(blockquote) {
+    border-left: 3px solid var(--color-accent);
+    padding-left: 16px;
+    color: var(--color-muted);
+    font-style: italic;
+    margin: 24px 0;
+  }
+  .prose :global(code) {
+    background: var(--color-border);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.9em;
+  }
+  .prose :global(pre) {
+    background: var(--color-border);
+    padding: 16px;
+    border-radius: 4px;
+    overflow-x: auto;
+  }
+  .prose :global(ul), .prose :global(ol) {
+    padding-left: 24px;
+    margin: 0 0 16px;
+  }
+  .prose :global(hr) {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 32px 0;
+  }
+  .writing-article-external {
+    margin-top: 48px;
+    padding: 20px;
+    background: var(--color-border);
+    border-radius: 6px;
+    font-size: 0.875rem;
+  }
+  .writing-article-external p {
+    margin: 0 0 6px;
+    color: var(--color-muted);
+  }
+  .writing-article-external a {
+    color: var(--color-accent);
+    word-break: break-all;
+  }
+</style>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -1,0 +1,83 @@
+---
+import Base from '~/layouts/Base.astro';
+import WritingCard from '~/components/WritingCard.astro';
+import { getPublishedWriting } from '~/lib/collections';
+
+const entries = await getPublishedWriting('en');
+// Fallback: if no English entries, show Korean ones with a notice.
+const fallbackKo = entries.length === 0 ? await getPublishedWriting('ko') : [];
+const displayEntries = entries.length > 0 ? entries : fallbackKo;
+const isKoFallback = entries.length === 0 && fallbackKo.length > 0;
+---
+<Base
+  title="Writing — Chaesang Jung | Ieum Tech"
+  description="Notes from thirty years between Silicon Valley and Seoul — on products, teams, and the words Korean tech has invented. By Chaesang Jung."
+  lang="en"
+  path="/writing"
+  ogType="website"
+  altLangPath="/ko/writing"
+>
+  <main>
+    <section class="writing-hero">
+      <div class="container">
+        <h1>Writing</h1>
+        <p class="writing-lead">
+          Essays on products I use, teams I've built, and the vocabulary Korean tech has
+          invented along the way. Most pieces were first published on Brunch (in Korean);
+          English translations are gradually being added.
+        </p>
+        {isKoFallback && (
+          <p class="writing-notice">
+            Currently in Korean. English translations are planned but not yet published.
+          </p>
+        )}
+      </div>
+    </section>
+
+    <section class="writing-list">
+      <div class="container">
+        {displayEntries.length === 0 ? (
+          <p class="writing-empty">No entries yet.</p>
+        ) : (
+          displayEntries.map((entry) => (
+            <WritingCard entry={entry} lang={isKoFallback ? 'ko' : 'en'} />
+          ))
+        )}
+      </div>
+    </section>
+  </main>
+</Base>
+
+<style>
+  .writing-hero {
+    padding: 64px 0 32px;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .writing-hero h1 {
+    font-size: 2.25rem;
+    margin: 0 0 12px;
+  }
+  .writing-lead {
+    font-size: 1rem;
+    color: var(--color-muted);
+    line-height: 1.7;
+    max-width: 640px;
+  }
+  .writing-notice {
+    font-size: 0.8125rem;
+    color: var(--color-muted);
+    margin-top: 12px;
+    padding: 8px 12px;
+    background: var(--color-border);
+    border-radius: 4px;
+    display: inline-block;
+  }
+  .writing-list {
+    padding: 32px 0 80px;
+  }
+  .writing-empty {
+    color: var(--color-muted);
+    padding: 32px 0;
+    text-align: center;
+  }
+</style>

--- a/src/pages/writing/series/[slug]/index.astro
+++ b/src/pages/writing/series/[slug]/index.astro
@@ -1,0 +1,92 @@
+---
+import Base from '~/layouts/Base.astro';
+import WritingCard from '~/components/WritingCard.astro';
+import { getActiveSeries, getWritingBySeries } from '~/lib/collections';
+
+export async function getStaticPaths() {
+  const series = await getActiveSeries('en');
+  return series.map((slug) => ({ params: { slug } }));
+}
+
+const { slug } = Astro.params;
+const entries = await getWritingBySeries(slug!, 'en');
+// Fallback to Korean if English empty
+const koEntries = entries.length === 0 ? await getWritingBySeries(slug!, 'ko') : [];
+const displayEntries = entries.length > 0 ? entries : koEntries;
+const isKoFallback = entries.length === 0 && koEntries.length > 0;
+---
+<Base
+  title={`${slug} — Writing — Chaesang Jung`}
+  description={`Writing series: ${slug}`}
+  lang="en"
+  path={`/writing/series/${slug}`}
+  ogType="website"
+  altLangPath={`/ko/writing/series/${slug}`}
+>
+  <main>
+    <section class="writing-hero">
+      <div class="container">
+        <nav class="writing-breadcrumb">
+          <a href="/writing">← Writing</a>
+        </nav>
+        <p class="writing-eyebrow">Series</p>
+        <h1>{slug}</h1>
+        <p class="writing-count">{displayEntries.length} {displayEntries.length === 1 ? 'entry' : 'entries'}</p>
+      </div>
+    </section>
+
+    <section class="writing-list">
+      <div class="container">
+        {displayEntries.length === 0 ? (
+          <p class="writing-empty">No entries in this series.</p>
+        ) : (
+          displayEntries.map((entry) => (
+            <WritingCard entry={entry} lang={isKoFallback ? 'ko' : 'en'} />
+          ))
+        )}
+      </div>
+    </section>
+  </main>
+</Base>
+
+<style>
+  .writing-hero {
+    padding: 64px 0 32px;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .writing-breadcrumb {
+    margin-bottom: 16px;
+    font-size: 0.875rem;
+  }
+  .writing-breadcrumb a {
+    color: var(--color-muted);
+    text-decoration: none;
+  }
+  .writing-breadcrumb a:hover { color: var(--color-accent); }
+  .writing-eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-accent);
+    margin: 0 0 6px;
+    font-weight: 600;
+  }
+  .writing-hero h1 {
+    font-size: 2rem;
+    margin: 0 0 8px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .writing-count {
+    font-size: 0.875rem;
+    color: var(--color-muted);
+    margin: 0;
+  }
+  .writing-list {
+    padding: 32px 0 80px;
+  }
+  .writing-empty {
+    color: var(--color-muted);
+    padding: 32px 0;
+    text-align: center;
+  }
+</style>


### PR DESCRIPTION
## Summary
Expose the 42 published Brunch articles (ingested in #38) through real pages:
- `/writing` list, `/writing/[slug]` detail, `/writing/series/[slug]` filtered list — both `en/` and `ko/`
- Home pages show the 3 most recent entries
- Nav gains a Writing entry

## Details
- `src/lib/collections.ts` centralizes queries (`getPublishedWriting`, `getWritingBySeries`, `getRecentWriting`, etc.)
- Detail page shows `externalUrl` at the bottom as "Originally published on Brunch"
- English side has no entries yet and falls back to Korean with a short notice; once translations exist they take over automatically

## Test plan
- [ ] Preview renders `/ko/writing`, `/ko/writing/chaesang-33`, `/ko/writing/series/svc-analysis`
- [ ] Home (`/ko/`) shows 3 most recent titles linking to the correct detail pages
- [ ] Header "글" link highlights on Writing sub-routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)