### PR TITLE
Surface series on Writing pages

### DIFF
--- a/src/components/SeriesCard.astro
+++ b/src/components/SeriesCard.astro
@@ -1,0 +1,66 @@
+---
+import type { SeriesEntry } from '~/lib/collections';
+import type { Lang } from '~/i18n/ui';
+
+interface Props {
+  series: SeriesEntry;
+  count: number;
+  lang: Lang;
+}
+
+const { series, count, lang } = Astro.props;
+const href = lang === 'en'
+  ? `/writing/series/${series.data.slug}`
+  : `/ko/writing/series/${series.data.slug}`;
+const title = series.data.titles[lang] ?? series.data.slug;
+const description = series.data.descriptions[lang];
+const countLabel = lang === 'ko' ? `${count}편` : `${count} ${count === 1 ? 'entry' : 'entries'}`;
+---
+<a class="series-card" href={href}>
+  <div class="series-card-head">
+    <h3 class="series-card-title">{title}</h3>
+    <span class="series-card-count">{countLabel}</span>
+  </div>
+  {description && <p class="series-card-desc">{description}</p>}
+</a>
+
+<style>
+  .series-card {
+    display: block;
+    padding: 20px 22px;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .series-card:hover {
+    border-color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 4%, transparent);
+  }
+  .series-card-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 8px;
+  }
+  .series-card-title {
+    font-size: 1.0625rem;
+    font-weight: 600;
+    margin: 0;
+    color: var(--color-text);
+    line-height: 1.4;
+  }
+  .series-card-count {
+    font-size: 0.8125rem;
+    color: var(--color-muted);
+    flex-shrink: 0;
+  }
+  .series-card-desc {
+    font-size: 0.875rem;
+    color: var(--color-muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+</style>

--- a/src/components/WritingCard.astro
+++ b/src/components/WritingCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { WritingEntry } from '~/lib/collections';
+import { seriesDisplayTitle } from '~/lib/collections';
 import type { Lang } from '~/i18n/ui';
 
 interface Props {
@@ -10,46 +11,32 @@ interface Props {
 const { entry, lang } = Astro.props;
 const slug = entry.slug.split('/').pop()!;
 const href = lang === 'en' ? `/writing/${slug}` : `/ko/writing/${slug}`;
+const seriesHref = entry.data.series
+  ? (lang === 'en' ? `/writing/series/${entry.data.series}` : `/ko/writing/series/${entry.data.series}`)
+  : null;
+const seriesTitle = entry.data.series ? await seriesDisplayTitle(entry.data.series, lang) : null;
 const dateLabel = entry.data.date.toLocaleDateString(lang === 'ko' ? 'ko-KR' : 'en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',
 });
-const sourceLabel =
-  entry.data.source === 'brunch' ? 'Brunch' :
-  entry.data.source === 'nia' ? 'NIA' :
-  entry.data.source === 'dbr' ? 'DBR' :
-  entry.data.source === 'linkedin' ? 'LinkedIn' : null;
 ---
 <article class="writing-card">
-  <a href={href} class="writing-card-link">
-    <div class="writing-card-meta">
-      <time datetime={entry.data.date.toISOString()}>{dateLabel}</time>
-      {sourceLabel && <span class="writing-card-source">{sourceLabel}</span>}
-      {entry.data.series && <span class="writing-card-series">{entry.data.series}</span>}
-    </div>
-    <h3 class="writing-card-title">{entry.data.title}</h3>
-    <p class="writing-card-summary">{entry.data.summary}</p>
-    {entry.data.tags.length > 0 && (
-      <div class="writing-card-tags">
-        {entry.data.tags.map((t) => <span class="writing-card-tag">#{t}</span>)}
-      </div>
+  <div class="writing-card-meta">
+    {seriesTitle && seriesHref && (
+      <a class="writing-card-series" href={seriesHref}>{seriesTitle}</a>
     )}
-  </a>
+    <time datetime={entry.data.date.toISOString()}>{dateLabel}</time>
+  </div>
+  <h2 class="writing-card-title">
+    <a href={href}>{entry.data.title}</a>
+  </h2>
 </article>
 
 <style>
   .writing-card {
     border-top: 1px solid var(--color-border);
-    padding: 24px 0;
-  }
-  .writing-card-link {
-    display: block;
-    color: inherit;
-    text-decoration: none;
-  }
-  .writing-card-link:hover .writing-card-title {
-    color: var(--color-accent);
+    padding: 20px 0;
   }
   .writing-card-meta {
     display: flex;
@@ -59,37 +46,30 @@ const sourceLabel =
     color: var(--color-muted);
     margin-bottom: 8px;
   }
-  .writing-card-source,
   .writing-card-series {
     font-size: 0.75rem;
     padding: 2px 8px;
     border-radius: 4px;
-    background: var(--color-border);
-    color: var(--color-muted);
+    background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+    color: var(--color-accent);
     font-weight: 500;
+    text-decoration: none;
+  }
+  .writing-card-series:hover {
+    background: color-mix(in srgb, var(--color-accent) 20%, transparent);
   }
   .writing-card-title {
-    font-size: 1.25rem;
+    font-size: 1.375rem;
     font-weight: 600;
     color: var(--color-text);
-    margin: 0 0 8px;
+    margin: 0;
     line-height: 1.4;
-    transition: color 0.15s ease;
   }
-  .writing-card-summary {
-    font-size: 0.9375rem;
-    color: var(--color-muted);
-    line-height: 1.6;
-    margin: 0 0 12px;
+  .writing-card-title a {
+    color: inherit;
+    text-decoration: none;
   }
-  .writing-card-tags {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-  }
-  .writing-card-tag {
-    font-size: 0.75rem;
+  .writing-card-title a:hover {
     color: var(--color-accent);
-    font-weight: 400;
   }
 </style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -78,4 +78,21 @@ const talks = defineCollection({
     }),
 });
 
-export const collections = { writing, portfolio, talks };
+const series = defineCollection({
+  type: 'data',
+  schema: z.object({
+    slug: z.string(),
+    titles: z.object({
+      en: z.string(),
+      ko: z.string(),
+    }),
+    descriptions: z.object({
+      en: z.string().optional(),
+      ko: z.string().optional(),
+    }).default({}),
+    order: z.number().default(100), // display order on /writing
+    featured: z.boolean().default(false),
+  }),
+});
+
+export const collections = { writing, portfolio, talks, series };

--- a/src/content/series/90s-com-eng.json
+++ b/src/content/series/90s-com-eng.json
@@ -1,0 +1,13 @@
+{
+  "slug": "90s-com-eng",
+  "titles": {
+    "ko": "90년대 컴퓨터 공학 이야기",
+    "en": "A 1990s Computer Engineering Story"
+  },
+  "descriptions": {
+    "ko": "80~90년대에 컴퓨터를 처음 만나 컴퓨터공학과를 다니던 시절의 기억들.",
+    "en": "Memoir: meeting computers in the 80s and studying computer engineering in the 90s."
+  },
+  "order": 70,
+  "featured": false
+}

--- a/src/content/series/chaesang-etc.json
+++ b/src/content/series/chaesang-etc.json
@@ -1,0 +1,7 @@
+{
+  "slug": "chaesang-etc",
+  "titles": { "ko": "사소한 이야기들", "en": "Odds and Ends" },
+  "descriptions": {},
+  "order": 50,
+  "featured": false
+}

--- a/src/content/series/chaesang-it-26.json
+++ b/src/content/series/chaesang-it-26.json
@@ -1,0 +1,7 @@
+{
+  "slug": "chaesang-it-26",
+  "titles": { "ko": "2026년 IT 생각들", "en": "IT Thoughts, 2026" },
+  "descriptions": {},
+  "order": 35,
+  "featured": false
+}

--- a/src/content/series/chaesang-priv.json
+++ b/src/content/series/chaesang-priv.json
@@ -1,0 +1,13 @@
+{
+  "slug": "chaesang-priv",
+  "titles": {
+    "ko": "일 관련 업데이트",
+    "en": "Work Updates"
+  },
+  "descriptions": {
+    "ko": "강의, 강연, 프로젝트 등 일과 관련된 업데이트들.",
+    "en": "Updates on lectures, talks, and ongoing projects."
+  },
+  "order": 40,
+  "featured": false
+}

--- a/src/content/series/dfmba-recom.json
+++ b/src/content/series/dfmba-recom.json
@@ -1,0 +1,10 @@
+{
+  "slug": "dfmba-recom",
+  "titles": { "ko": "KAIST DFMBA 2023", "en": "KAIST DFMBA 2023" },
+  "descriptions": {
+    "ko": "KAIST 경영대학 디지털금융 MBA — AI와 추천 시스템 강의 노트 (2023, 첫 해).",
+    "en": "Lecture notes for KAIST DFMBA — AI and Recommendation Systems (2023, inaugural)."
+  },
+  "order": 62,
+  "featured": false
+}

--- a/src/content/series/do-well-company.json
+++ b/src/content/series/do-well-company.json
@@ -1,0 +1,13 @@
+{
+  "slug": "do-well-company",
+  "titles": {
+    "ko": "회사에서의 기억들",
+    "en": "Memories from Companies"
+  },
+  "descriptions": {
+    "ko": "여러 회사에서 엔지니어로, 매니저로, 경영자로 일하며 남은 장면들. 조직과 사람에 관한 기억들.",
+    "en": "Scenes from working as an engineer, manager, and executive across several companies — about organizations and the people in them."
+  },
+  "order": 20,
+  "featured": true
+}

--- a/src/content/series/itterm.json
+++ b/src/content/series/itterm.json
@@ -1,0 +1,13 @@
+{
+  "slug": "itterm",
+  "titles": {
+    "ko": "한국 IT 용어 이야기",
+    "en": "Korean IT Terms"
+  },
+  "descriptions": {
+    "ko": "한국 IT 현장에서 반복해서 듣는 단어들을 한 편씩 풀어 봅니다. 미국과 한국, 두 쪽을 오가며 들으며 쌓인 관찰입니다.",
+    "en": "One term at a time, observed from working between Silicon Valley and Seoul."
+  },
+  "order": 30,
+  "featured": true
+}

--- a/src/content/series/kaist-dfmba-24.json
+++ b/src/content/series/kaist-dfmba-24.json
@@ -1,0 +1,10 @@
+{
+  "slug": "kaist-dfmba-24",
+  "titles": { "ko": "KAIST DFMBA 2024", "en": "KAIST DFMBA 2024" },
+  "descriptions": {
+    "ko": "KAIST 경영대학 디지털금융 MBA — AI와 추천 시스템 강의 노트 (2024).",
+    "en": "Lecture notes for KAIST DFMBA — AI and Recommendation Systems (2024)."
+  },
+  "order": 61,
+  "featured": false
+}

--- a/src/content/series/kaist-dfmba-25.json
+++ b/src/content/series/kaist-dfmba-25.json
@@ -1,0 +1,10 @@
+{
+  "slug": "kaist-dfmba-25",
+  "titles": { "ko": "KAIST DFMBA 2025", "en": "KAIST DFMBA 2025" },
+  "descriptions": {
+    "ko": "KAIST 경영대학 디지털금융 MBA — AI와 추천 시스템 강의 노트 (2025).",
+    "en": "Lecture notes for KAIST DFMBA — AI and Recommendation Systems (2025)."
+  },
+  "order": 60,
+  "featured": false
+}

--- a/src/content/series/svc-analysis.json
+++ b/src/content/series/svc-analysis.json
@@ -1,0 +1,13 @@
+{
+  "slug": "svc-analysis",
+  "titles": {
+    "ko": "혼자 해 보는 서비스 분석",
+    "en": "Solo Service Analyses"
+  },
+  "descriptions": {
+    "ko": "사용자의 입장 혹은 참관인의 입장에서 '내맘대로 제품 분석' 글을 모아 둡니다. 사소한 걱정과 지적에서 시작해 가급적 제안까지 담아 봅니다.",
+    "en": "Product reviews from a user's or bystander's vantage point — small worries and critiques, usually with a concrete suggestion."
+  },
+  "order": 10,
+  "featured": true
+}

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -1,7 +1,44 @@
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { getCollection, getEntry, type CollectionEntry } from 'astro:content';
 import type { Lang } from '~/i18n/ui';
 
 export type WritingEntry = CollectionEntry<'writing'>;
+export type SeriesEntry = CollectionEntry<'series'>;
+
+/** Series metadata by slug. Returns undefined if missing. */
+export async function getSeriesMeta(slug: string): Promise<SeriesEntry | undefined> {
+  return getEntry('series', slug);
+}
+
+/** Display title for a series in a given language, falling back to slug. */
+export async function seriesDisplayTitle(slug: string, lang: Lang): Promise<string> {
+  const meta = await getSeriesMeta(slug);
+  return meta?.data.titles[lang] ?? slug;
+}
+
+/** All series entries, sorted by `order`. */
+export async function getAllSeries(): Promise<SeriesEntry[]> {
+  const all = await getCollection('series');
+  return all.sort((a, b) => a.data.order - b.data.order);
+}
+
+/** Active series that have at least one published entry in the given language. */
+export async function getActiveSeriesWithMeta(
+  lang: Lang,
+): Promise<Array<{ meta: SeriesEntry; count: number }>> {
+  const entries = await getPublishedWriting(lang);
+  const counts = new Map<string, number>();
+  for (const e of entries) {
+    if (!e.data.series) continue;
+    counts.set(e.data.series, (counts.get(e.data.series) ?? 0) + 1);
+  }
+  const allSeries = await getAllSeries();
+  const result: Array<{ meta: SeriesEntry; count: number }> = [];
+  for (const s of allSeries) {
+    const count = counts.get(s.data.slug) ?? 0;
+    if (count > 0) result.push({ meta: s, count });
+  }
+  return result;
+}
 
 /** Published entries (draft=false) in one language, newest first. */
 export async function getPublishedWriting(lang: Lang): Promise<WritingEntry[]> {

--- a/src/pages/ko/writing/[slug]/index.astro
+++ b/src/pages/ko/writing/[slug]/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Base from '~/layouts/Base.astro';
+import { seriesDisplayTitle } from '~/lib/collections';
 
 export async function getStaticPaths() {
   const entries = await getCollection('writing', (e) => !e.data.draft && e.data.lang === 'ko');
@@ -22,6 +23,7 @@ const sourceLabel =
   entry.data.source === 'nia' ? 'NIA' :
   entry.data.source === 'dbr' ? 'DBR' :
   entry.data.source === 'linkedin' ? 'LinkedIn' : null;
+const seriesTitle = entry.data.series ? await seriesDisplayTitle(entry.data.series, 'ko') : null;
 ---
 <Base
   title={`${entry.data.title} — 정채상`}
@@ -49,9 +51,9 @@ const sourceLabel =
           <div class="writing-article-meta">
             <time datetime={entry.data.date.toISOString()}>{dateLabel}</time>
             {sourceLabel && <span class="writing-article-source">{sourceLabel}</span>}
-            {entry.data.series && (
+            {entry.data.series && seriesTitle && (
               <a class="writing-article-series" href={`/ko/writing/series/${entry.data.series}`}>
-                {entry.data.series}
+                {seriesTitle}
               </a>
             )}
           </div>
@@ -94,17 +96,26 @@ const sourceLabel =
     color: var(--color-muted);
     margin-bottom: 16px;
   }
-  .writing-article-source,
-  .writing-article-series {
+  .writing-article-source {
     font-size: 0.75rem;
     padding: 2px 8px;
     border-radius: 4px;
     background: var(--color-border);
     color: var(--color-muted);
     font-weight: 500;
+  }
+  .writing-article-series {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+    color: var(--color-accent);
+    font-weight: 500;
     text-decoration: none;
   }
-  .writing-article-series:hover { color: var(--color-accent); }
+  .writing-article-series:hover {
+    background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+  }
   .writing-article-title {
     font-size: 2rem;
     font-weight: 600;

--- a/src/pages/ko/writing/index.astro
+++ b/src/pages/ko/writing/index.astro
@@ -1,9 +1,11 @@
 ---
 import Base from '~/layouts/Base.astro';
 import WritingCard from '~/components/WritingCard.astro';
-import { getPublishedWriting } from '~/lib/collections';
+import SeriesCard from '~/components/SeriesCard.astro';
+import { getPublishedWriting, getActiveSeriesWithMeta } from '~/lib/collections';
 
 const entries = await getPublishedWriting('ko');
+const seriesList = await getActiveSeriesWithMeta('ko');
 ---
 <Base
   title="글 — 정채상 | 이음 테크"
@@ -31,8 +33,22 @@ const entries = await getPublishedWriting('ko');
       </div>
     </section>
 
+    {seriesList.length > 0 && (
+      <section class="writing-series">
+        <div class="container">
+          <h2 class="section-label">시리즈</h2>
+          <div class="series-grid">
+            {seriesList.map(({ meta, count }) => (
+              <SeriesCard series={meta} count={count} lang="ko" />
+            ))}
+          </div>
+        </div>
+      </section>
+    )}
+
     <section class="writing-list">
       <div class="container">
+        <h2 class="section-label">최신 글</h2>
         {entries.length === 0 ? (
           <p class="writing-empty">글이 아직 없습니다.</p>
         ) : (
@@ -57,9 +73,26 @@ const entries = await getPublishedWriting('ko');
     color: var(--color-muted);
     line-height: 1.7;
     max-width: 640px;
+    margin: 0;
+  }
+  .section-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-muted);
+    font-weight: 600;
+    margin: 0 0 20px;
+  }
+  .writing-series {
+    padding: 40px 0 16px;
+  }
+  .series-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
   }
   .writing-list {
-    padding: 32px 0 80px;
+    padding: 40px 0 80px;
   }
   .writing-empty {
     color: var(--color-muted);

--- a/src/pages/ko/writing/series/[slug]/index.astro
+++ b/src/pages/ko/writing/series/[slug]/index.astro
@@ -1,7 +1,7 @@
 ---
 import Base from '~/layouts/Base.astro';
 import WritingCard from '~/components/WritingCard.astro';
-import { getActiveSeries, getWritingBySeries } from '~/lib/collections';
+import { getActiveSeries, getWritingBySeries, getSeriesMeta } from '~/lib/collections';
 
 export async function getStaticPaths() {
   const series = await getActiveSeries('ko');
@@ -10,10 +10,13 @@ export async function getStaticPaths() {
 
 const { slug } = Astro.params;
 const entries = await getWritingBySeries(slug!, 'ko');
+const meta = await getSeriesMeta(slug!);
+const title = meta?.data.titles.ko ?? slug!;
+const description = meta?.data.descriptions.ko;
 ---
 <Base
-  title={`${slug} — 글 — 정채상`}
-  description={`시리즈: ${slug}`}
+  title={`${title} — 글 — 정채상`}
+  description={description ?? `시리즈: ${title}`}
   lang="ko"
   path={`/ko/writing/series/${slug}`}
   ogType="website"
@@ -33,7 +36,8 @@ const entries = await getWritingBySeries(slug!, 'ko');
           <a href="/ko/writing">← 글 목록</a>
         </nav>
         <p class="writing-eyebrow">시리즈</p>
-        <h1>{slug}</h1>
+        <h1>{title}</h1>
+        {description && <p class="writing-lead">{description}</p>}
         <p class="writing-count">{entries.length}편</p>
       </div>
     </section>
@@ -65,8 +69,15 @@ const entries = await getWritingBySeries(slug!, 'ko');
   }
   .writing-hero h1 {
     font-size: 2rem;
-    margin: 0 0 8px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    margin: 0 0 12px;
+    line-height: 1.3;
+  }
+  .writing-lead {
+    font-size: 1rem;
+    color: var(--color-muted);
+    line-height: 1.7;
+    max-width: 640px;
+    margin: 0 0 16px;
   }
   .writing-count { font-size: 0.875rem; color: var(--color-muted); margin: 0; }
   .writing-list { padding: 32px 0 80px; }

--- a/src/pages/writing/[slug]/index.astro
+++ b/src/pages/writing/[slug]/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Base from '~/layouts/Base.astro';
+import { seriesDisplayTitle } from '~/lib/collections';
 
 export async function getStaticPaths() {
   const entries = await getCollection('writing', (e) => !e.data.draft && e.data.lang === 'en');
@@ -22,6 +23,7 @@ const sourceLabel =
   entry.data.source === 'nia' ? 'NIA' :
   entry.data.source === 'dbr' ? 'DBR' :
   entry.data.source === 'linkedin' ? 'LinkedIn' : null;
+const seriesTitle = entry.data.series ? await seriesDisplayTitle(entry.data.series, 'en') : null;
 ---
 <Base
   title={`${entry.data.title} — Chaesang Jung`}
@@ -42,9 +44,9 @@ const sourceLabel =
           <div class="writing-article-meta">
             <time datetime={entry.data.date.toISOString()}>{dateLabel}</time>
             {sourceLabel && <span class="writing-article-source">{sourceLabel}</span>}
-            {entry.data.series && (
+            {entry.data.series && seriesTitle && (
               <a class="writing-article-series" href={`/writing/series/${entry.data.series}`}>
-                {entry.data.series}
+                {seriesTitle}
               </a>
             )}
           </div>
@@ -99,17 +101,26 @@ const sourceLabel =
     color: var(--color-muted);
     margin-bottom: 16px;
   }
-  .writing-article-source,
-  .writing-article-series {
+  .writing-article-source {
     font-size: 0.75rem;
     padding: 2px 8px;
     border-radius: 4px;
     background: var(--color-border);
     color: var(--color-muted);
     font-weight: 500;
+  }
+  .writing-article-series {
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+    color: var(--color-accent);
+    font-weight: 500;
     text-decoration: none;
   }
-  .writing-article-series:hover { color: var(--color-accent); }
+  .writing-article-series:hover {
+    background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+  }
   .writing-article-title {
     font-size: 2rem;
     font-weight: 600;

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -1,13 +1,16 @@
 ---
 import Base from '~/layouts/Base.astro';
 import WritingCard from '~/components/WritingCard.astro';
-import { getPublishedWriting } from '~/lib/collections';
+import SeriesCard from '~/components/SeriesCard.astro';
+import { getPublishedWriting, getActiveSeriesWithMeta } from '~/lib/collections';
 
-const entries = await getPublishedWriting('en');
-// Fallback: if no English entries, show Korean ones with a notice.
-const fallbackKo = entries.length === 0 ? await getPublishedWriting('ko') : [];
-const displayEntries = entries.length > 0 ? entries : fallbackKo;
-const isKoFallback = entries.length === 0 && fallbackKo.length > 0;
+const enEntries = await getPublishedWriting('en');
+const enSeries = await getActiveSeriesWithMeta('en');
+
+const isKoFallback = enEntries.length === 0;
+const entries = isKoFallback ? await getPublishedWriting('ko') : enEntries;
+const seriesList = isKoFallback ? await getActiveSeriesWithMeta('ko') : enSeries;
+const displayLang = isKoFallback ? 'ko' : 'en';
 ---
 <Base
   title="Writing — Chaesang Jung | Ieum Tech"
@@ -34,14 +37,26 @@ const isKoFallback = entries.length === 0 && fallbackKo.length > 0;
       </div>
     </section>
 
+    {seriesList.length > 0 && (
+      <section class="writing-series">
+        <div class="container">
+          <h2 class="section-label">Series</h2>
+          <div class="series-grid">
+            {seriesList.map(({ meta, count }) => (
+              <SeriesCard series={meta} count={count} lang={displayLang} />
+            ))}
+          </div>
+        </div>
+      </section>
+    )}
+
     <section class="writing-list">
       <div class="container">
-        {displayEntries.length === 0 ? (
+        <h2 class="section-label">Latest</h2>
+        {entries.length === 0 ? (
           <p class="writing-empty">No entries yet.</p>
         ) : (
-          displayEntries.map((entry) => (
-            <WritingCard entry={entry} lang={isKoFallback ? 'ko' : 'en'} />
-          ))
+          entries.map((entry) => <WritingCard entry={entry} lang={displayLang} />)
         )}
       </div>
     </section>
@@ -62,6 +77,7 @@ const isKoFallback = entries.length === 0 && fallbackKo.length > 0;
     color: var(--color-muted);
     line-height: 1.7;
     max-width: 640px;
+    margin: 0;
   }
   .writing-notice {
     font-size: 0.8125rem;
@@ -72,8 +88,24 @@ const isKoFallback = entries.length === 0 && fallbackKo.length > 0;
     border-radius: 4px;
     display: inline-block;
   }
+  .section-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-muted);
+    font-weight: 600;
+    margin: 0 0 20px;
+  }
+  .writing-series {
+    padding: 40px 0 16px;
+  }
+  .series-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+  }
   .writing-list {
-    padding: 32px 0 80px;
+    padding: 40px 0 80px;
   }
   .writing-empty {
     color: var(--color-muted);

--- a/src/pages/writing/series/[slug]/index.astro
+++ b/src/pages/writing/series/[slug]/index.astro
@@ -1,23 +1,28 @@
 ---
 import Base from '~/layouts/Base.astro';
 import WritingCard from '~/components/WritingCard.astro';
-import { getActiveSeries, getWritingBySeries } from '~/lib/collections';
+import { getActiveSeries, getWritingBySeries, getSeriesMeta } from '~/lib/collections';
 
 export async function getStaticPaths() {
-  const series = await getActiveSeries('en');
-  return series.map((slug) => ({ params: { slug } }));
+  // Cover both EN and KO series slugs so /writing/series/* works even when falling back to KO entries
+  const en = await getActiveSeries('en');
+  const ko = await getActiveSeries('ko');
+  const all = Array.from(new Set([...en, ...ko]));
+  return all.map((slug) => ({ params: { slug } }));
 }
 
 const { slug } = Astro.params;
-const entries = await getWritingBySeries(slug!, 'en');
-// Fallback to Korean if English empty
-const koEntries = entries.length === 0 ? await getWritingBySeries(slug!, 'ko') : [];
-const displayEntries = entries.length > 0 ? entries : koEntries;
-const isKoFallback = entries.length === 0 && koEntries.length > 0;
+const enEntries = await getWritingBySeries(slug!, 'en');
+const isKoFallback = enEntries.length === 0;
+const entries = isKoFallback ? await getWritingBySeries(slug!, 'ko') : enEntries;
+const displayLang = isKoFallback ? 'ko' : 'en';
+const meta = await getSeriesMeta(slug!);
+const title = meta?.data.titles[displayLang] ?? slug!;
+const description = meta?.data.descriptions[displayLang];
 ---
 <Base
-  title={`${slug} — Writing — Chaesang Jung`}
-  description={`Writing series: ${slug}`}
+  title={`${title} — Writing — Chaesang Jung`}
+  description={description ?? `Writing series: ${title}`}
   lang="en"
   path={`/writing/series/${slug}`}
   ogType="website"
@@ -30,19 +35,18 @@ const isKoFallback = entries.length === 0 && koEntries.length > 0;
           <a href="/writing">← Writing</a>
         </nav>
         <p class="writing-eyebrow">Series</p>
-        <h1>{slug}</h1>
-        <p class="writing-count">{displayEntries.length} {displayEntries.length === 1 ? 'entry' : 'entries'}</p>
+        <h1>{title}</h1>
+        {description && <p class="writing-lead">{description}</p>}
+        <p class="writing-count">{entries.length} {entries.length === 1 ? 'entry' : 'entries'}</p>
       </div>
     </section>
 
     <section class="writing-list">
       <div class="container">
-        {displayEntries.length === 0 ? (
+        {entries.length === 0 ? (
           <p class="writing-empty">No entries in this series.</p>
         ) : (
-          displayEntries.map((entry) => (
-            <WritingCard entry={entry} lang={isKoFallback ? 'ko' : 'en'} />
-          ))
+          entries.map((entry) => <WritingCard entry={entry} lang={displayLang} />)
         )}
       </div>
     </section>
@@ -50,18 +54,9 @@ const isKoFallback = entries.length === 0 && koEntries.length > 0;
 </Base>
 
 <style>
-  .writing-hero {
-    padding: 64px 0 32px;
-    border-bottom: 1px solid var(--color-border);
-  }
-  .writing-breadcrumb {
-    margin-bottom: 16px;
-    font-size: 0.875rem;
-  }
-  .writing-breadcrumb a {
-    color: var(--color-muted);
-    text-decoration: none;
-  }
+  .writing-hero { padding: 64px 0 32px; border-bottom: 1px solid var(--color-border); }
+  .writing-breadcrumb { margin-bottom: 16px; font-size: 0.875rem; }
+  .writing-breadcrumb a { color: var(--color-muted); text-decoration: none; }
   .writing-breadcrumb a:hover { color: var(--color-accent); }
   .writing-eyebrow {
     font-size: 0.75rem;
@@ -73,20 +68,17 @@ const isKoFallback = entries.length === 0 && koEntries.length > 0;
   }
   .writing-hero h1 {
     font-size: 2rem;
-    margin: 0 0 8px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    margin: 0 0 12px;
+    line-height: 1.3;
   }
-  .writing-count {
-    font-size: 0.875rem;
+  .writing-lead {
+    font-size: 1rem;
     color: var(--color-muted);
-    margin: 0;
+    line-height: 1.7;
+    max-width: 640px;
+    margin: 0 0 16px;
   }
-  .writing-list {
-    padding: 32px 0 80px;
-  }
-  .writing-empty {
-    color: var(--color-muted);
-    padding: 32px 0;
-    text-align: center;
-  }
+  .writing-count { font-size: 0.875rem; color: var(--color-muted); margin: 0; }
+  .writing-list { padding: 32px 0 80px; }
+  .writing-empty { color: var(--color-muted); padding: 32px 0; text-align: center; }
 </style>


### PR DESCRIPTION
## Summary
Addresses the feedback from architect/marketer/developer on Writing structure: the series axis was the intentional editorial layer, but it was invisible from the list page.

## Changes
- New `series` data collection (`src/content/series/*.json`). Each series has Korean + English titles, optional descriptions, and a display order. All 10 currently-ingested series seeded (3 published + 7 draft).
- `/writing` and `/ko/writing` now render a Series card grid at the top, then the Latest list underneath.
- Series detail page reads title/description from the collection instead of showing the raw slug.
- WritingCard simplified — series chip · date · title (h2). Summary was often a verbatim first paragraph (no signal); tags weren't filterable yet.
- Series badge gets an accent background so it's visibly a link (source stays a muted label).
- Detail pages now show the Korean series title in place of the slug.

## Left for later (priority 2, separate PR)
- Home "Recent Writing" widget redesign (3 series representatives instead of 3 newest)
- Image alt + lazy loading + Astro `<Image>` processing
- prose max-width 720 → 640, card title size tweaks, body font consolidation
- Tag page `/writing/tag/[tag]` and tag hygiene
- Pagination once published count crosses ~80

## Test plan
- [ ] Preview renders `/ko/writing` with three Series cards above the Latest list
- [ ] Series cards link to `/ko/writing/series/<slug>` with Korean title and description
- [ ] Card chips on the list and detail pages display the Korean series name, not the slug
- [ ] Build passes (54 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)