### PR TITLE
Redesign home and nav for repositioning (PR 1 of 3)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,20 +7,20 @@ interface Props {
   currentPath: string;
 }
 
-const { lang, currentPath } = Astro.props;
+const { lang } = Astro.props;
 const t = useTranslations(lang);
 
 const homePath = localizedPath('/', lang);
 const aboutPath = localizedPath('/about', lang);
-const contactHref = currentPath === homePath ? '#contact' : `${homePath}#contact`;
+const writingPath = localizedPath('/writing', lang);
 ---
 <footer class="site-footer">
   <div class="footer-inner">
     <a href={homePath} class="footer-logo">{lang === 'ko' ? '이음 테크' : 'Ieum Tech'}</a>
     <nav class="footer-nav" aria-label="Footer navigation">
-      <a href={homePath}>{t('nav.home')}</a>
       <a href={aboutPath}>{t('nav.about')}</a>
-      <a href={contactHref}>{t('nav.contact')}</a>
+      <a href={writingPath}>{t('nav.writing')}</a>
+      <a href="mailto:hello@ieumtech.net">Email</a>
       <a href="https://linkedin.com/in/chaesang" target="_blank" rel="noopener noreferrer">LinkedIn</a>
       <a href="https://brunch.co.kr/@chaesang" target="_blank" rel="noopener noreferrer">Brunch</a>
     </nav>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,7 +14,6 @@ const t = useTranslations(lang);
 const homePath = localizedPath('/', lang);
 const aboutPath = localizedPath('/about', lang);
 const writingPath = localizedPath('/writing', lang);
-const contactHref = currentPath === homePath ? '#contact' : `${homePath}#contact`;
 const isWritingActive = currentPath === writingPath || currentPath.startsWith(`${writingPath}/`);
 
 const otherLang: Lang = lang === 'en' ? 'ko' : 'en';
@@ -34,10 +33,8 @@ const toggleLabel = otherLang === 'ko' ? 'KO' : 'EN';
         <span></span><span></span><span></span>
       </button>
       <ul class="nav-links" id="nav-menu">
-        <li><a href={homePath}>{t('nav.home')}</a></li>
         <li><a href={aboutPath} class={currentPath === aboutPath ? 'active' : ''} aria-current={currentPath === aboutPath ? 'page' : undefined}>{t('nav.about')}</a></li>
         <li><a href={writingPath} class={isWritingActive ? 'active' : ''} aria-current={isWritingActive ? 'page' : undefined}>{t('nav.writing')}</a></li>
-        <li><a href={contactHref}>{t('nav.contact')}</a></li>
       </ul>
       <a href={toggleHref} class="lang-toggle">{toggleLabel}</a>
     </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -48,16 +48,17 @@ const jsonLd = {
           <div>
             <h1 class="profile-name">Chaesang Jung</h1>
             <p class="profile-secondary-name">정채상</p>
-            <p class="profile-headline">Behind every technology, there were people — I carry those stories forward.</p>
+            <p class="profile-headline">Behind the technology, there were always people.</p>
           </div>
         </div>
 
         <div class="about-summary">
           <ul>
-            <li>Diverse domains — embedded, search, commerce, fintech, cloud, AI</li>
-            <li>Google 13 years (US) + Banksalad / MegazoneCloud / KAIST (Korea)</li>
-            <li>0 to scale — grew App Indexing from a demo to 50-person org; VPE at Banksalad (40+ engineers)</li>
-            <li>Teaching & sharing — KAIST adjunct professor, online courses, mentoring</li>
+            <li>Embedded, search, commerce, fintech, cloud, industrial AI</li>
+            <li>13 years in Silicon Valley, the years before and after in Korea</li>
+            <li>Engineer, manager, VP, CTO, advisor — a handful of roles along the way</li>
+            <li>Projects that worked, projects that quietly wound down</li>
+            <li>Still learning, and occasionally passing along what comes into view early.</li>
           </ul>
         </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,34 +9,34 @@ const writingBase = highlightLang === 'ko' ? '/ko/writing' : '/writing';
 
 const jsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'ProfessionalService',
-  name: 'Ieum Tech',
-  url: 'https://ieumtech.net',
-  description: 'Chaesang Jung connects ideas, people, and technology.',
-  founder: {
-    '@type': 'Person',
-    name: 'Chaesang Jung',
-    jobTitle: 'Founder',
-    sameAs: 'https://linkedin.com/in/chaesang',
-  },
-  contactPoint: {
-    '@type': 'ContactPoint',
-    email: 'hello@ieumtech.net',
-  },
+  '@type': 'Person',
+  name: 'Chaesang Jung',
+  alternateName: '정채상',
+  url: 'https://ieumtech.net/',
+  sameAs: 'https://linkedin.com/in/chaesang',
+  description: 'Thirty years in IT, between Korea and Silicon Valley.',
 };
 ---
 <Base
-  title="Chaesang Jung — Connecting Technology and People | Ieum Tech"
-  description="Chaesang Jung connects ideas, people, and technology. Tech direction, team challenges, what comes next — let's think it through together."
-  ogTitle="Connecting Technology and People | Chaesang Jung"
-  ogDescription="The things you've been thinking through alone — let's figure it out together."
+  title="Chaesang Jung · 정채상 — Ieum"
+  description="Thirty years in IT, between Korea and Silicon Valley. A place for what has been learned along the way."
+  ogTitle="Chaesang Jung · 정채상"
+  ogDescription="Thirty years in IT, between Korea and Silicon Valley."
   lang="en"
   path="/"
-  ogType="website"
+  ogType="profile"
   jsonLd={jsonLd}
   altLangPath="/ko/"
 >
   <style slot="head" is:inline>
+    .hero-inner { padding: 64px 24px 48px; max-width: 640px; margin: 0 auto; }
+    .hero-profile { margin-bottom: 20px; }
+    .hero-profile img { border-radius: 50%; width: 96px; height: 96px; object-fit: cover; }
+    .hero-name { font-size: 1.75rem; font-weight: 600; margin: 0 0 4px; color: var(--color-text); }
+    .hero-name-en { font-size: 0.9375rem; color: var(--color-muted); margin: 0 0 28px; }
+    .hero-intro p { font-size: 1.0625rem; line-height: 1.7; color: var(--color-text); margin: 0 0 10px; }
+    .hero-intro p:last-child { margin-bottom: 0; }
+
     .recent-writing { padding: 48px 0; border-top: 1px solid var(--color-border); }
     .recent-writing-header { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 24px; }
     .recent-writing-header h2 { margin: 0; font-size: 1.25rem; }
@@ -51,78 +51,24 @@ const jsonLd = {
     .recent-writing-desc { font-size: 0.875rem; color: var(--color-muted); margin: 6px 0 10px; line-height: 1.6; }
     .recent-writing-latest { font-size: 0.9375rem; color: var(--color-text); text-decoration: none; display: inline-block; }
     .recent-writing-latest:hover { color: var(--color-accent); }
-    .highlights-grid { display: flex; flex-direction: column; gap: 14px; }
-    .highlight-card { text-align: center; }
-    .highlight-text { font-size: 0.9375rem; font-weight: 500; color: var(--color-text); line-height: 1.5; }
-    .service-card.audience-card { display: flex; align-items: baseline; justify-content: space-between; gap: 24px; padding: 18px 24px; }
-    .service-card.audience-card h3 { flex-shrink: 0; margin-bottom: 0; }
-    .service-card.audience-card p { margin: 0; text-align: right; }
-    @media (max-width: 480px) {
-      .service-card.audience-card { flex-direction: column; align-items: flex-start; gap: 6px; }
-      .service-card.audience-card h3 { min-width: auto; }
-    }
   </style>
 
   <section class="hero" id="home">
     <div class="hero-inner">
-      <p class="hero-sublabel">The threads Chaesang, an engineer, keeps weaving</p>
-      <div class="connecting-list">
-        <h1 class="connecting-item"><span class="connecting-word">Connecting</span> ideas with technology.</h1>
-        <p class="connecting-item"><span class="connecting-word">Connecting</span> people, generations, and what's ahead.</p>
+      <div class="hero-profile">
+        <img src="/profile.jpg" alt="Chaesang Jung" width="96" height="96" loading="lazy" />
       </div>
-      <p class="hero-sub">The things you've been mulling over alone — tech direction, team dynamics, what comes next.<br />Let's think it through together.</p>
-      <p class="hero-vision">Technology deepens only when it passes between people.</p>
+      <h1 class="hero-name">Chaesang Jung</h1>
+      <p class="hero-name-en">정채상</p>
+      <div class="hero-intro">
+        <p>Thirty years in IT, between Korea and Silicon Valley.</p>
+        <p>Working between people and technology through the changes,</p>
+        <p>and keeping what has been learned along the way here.</p>
+      </div>
     </div>
   </section>
 
   <main>
-    <div class="highlights">
-      <div class="highlights-inner">
-        <div class="highlights-grid">
-          <div class="highlight-card"><div class="highlight-text">A couple of decades in the field</div></div>
-          <div class="highlight-card"><div class="highlight-text">13 years at Google</div></div>
-          <div class="highlight-card"><div class="highlight-text">Leading teams of dozens</div></div>
-          <div class="highlight-card"><div class="highlight-text">Firmware to AI, engineer to executive</div></div>
-        </div>
-      </div>
-    </div>
-
-    <div class="container">
-      <section id="services" style="border-top: 1px solid var(--color-border); margin-top: 0;">
-        <h2>Where I've Been</h2>
-        <p style="font-size: 0.9375rem; color: var(--color-muted); font-weight: 300; line-height: 1.8; margin-bottom: 28px;">
-          From writing set-top box firmware, to refining search results one line at a time, to building an app ecosystem from scratch, to wiring up a payment system solo, to slashing cloud costs, to watching AI predict furnace temperatures — each chapter looked completely different.<br /><br />
-          As an engineer, a manager, a VP, a CTO, an advisor — every role shift revealed something new.
-        </p>
-
-        <h2>Who I'm Here For</h2>
-        <div class="services-grid" style="grid-template-columns: 1fr;">
-          <div class="service-card audience-card">
-            <h3>First-time managers</h3>
-            <p>For the part nobody prepared you for.</p>
-          </div>
-          <div class="service-card audience-card">
-            <h3>Leaders facing the next wall</h3>
-            <p>When growing pains turn into harder questions.</p>
-          </div>
-          <div class="service-card audience-card">
-            <h3>Silicon Valley meets Korea</h3>
-            <p>For when both sides need a bridge.</p>
-          </div>
-        </div>
-        <p style="font-size: 0.875rem; color: var(--color-muted); font-weight: 400; margin-top: 16px; text-align: center;">If you have a good question, that's usually enough. Let's talk.</p>
-
-        <h2 style="margin-top: 32px;">Ways We Can Work Together</h2>
-        <div class="services-grid" style="grid-template-columns: 1fr;">
-          <div class="service-card audience-card"><h3>Teaching</h3><p>KAIST DFMBA — AI & Recommendation Systems</p></div>
-          <div class="service-card audience-card"><h3>Mentoring</h3><p>1:1 mentoring, Kernel360</p></div>
-          <div class="service-card audience-card"><h3>Speaking</h3><p>Talks, interviews, podcasts</p></div>
-          <div class="service-card audience-card"><h3>Online Courses</h3><p>Inflearn, Class101, FastCampus, HanbitN</p></div>
-          <div class="service-card audience-card"><h3>Writing</h3><p>Brunch · NIA monthly column</p></div>
-        </div>
-      </section>
-    </div>
-
     {highlights.length > 0 && (
       <section class="recent-writing">
         <div class="container">
@@ -153,25 +99,9 @@ const jsonLd = {
       </section>
     )}
 
-    <section id="founder" class="about-section">
-      <div class="about-inner">
-        <div class="about-profile">
-          <div class="profile-avatar"><img src="/profile.jpg" alt="Chaesang Jung" width="96" height="96" loading="lazy" /></div>
-          <div>
-            <h2 class="profile-name">Chaesang Jung</h2>
-            <p class="profile-secondary-name">정채상</p>
-            <p class="profile-headline">Behind every technology, there were people — and some of those stories took years to understand. Hoping to shorten that road for others.</p>
-          </div>
-        </div>
-        <div style="margin-top: 24px;">
-          <a href="/about" class="btn btn-outline btn-sm">More about Chaesang →</a>
-        </div>
-      </div>
-    </section>
-
     <section class="cta-section" id="contact" aria-labelledby="cta-heading">
       <div class="cta-inner">
-        <h2 class="cta-heading" id="cta-heading">If you have a story to connect, reach out.</h2>
+        <h2 class="cta-heading" id="cta-heading">If there's a thread worth pulling on, let's pull on it together.</h2>
         <div class="cta-buttons">
           <a href="mailto:hello@ieumtech.net" class="btn">Email</a>
           <a href="https://linkedin.com/in/chaesang" target="_blank" rel="noopener noreferrer" class="btn btn-outline">LinkedIn</a>

--- a/src/pages/ko/about.astro
+++ b/src/pages/ko/about.astro
@@ -43,16 +43,17 @@ const jsonLd = {
           <div>
             <h1 class="profile-name">정채상</h1>
             <p class="profile-secondary-name">Chaesang Jung</p>
-            <p class="profile-headline">기술이 지나온 자리에 사람이 있었고, 그 이야기를 잇습니다.</p>
+            <p class="profile-headline">기술이 지나온 자리에 늘 사람이 있었습니다.</p>
           </div>
         </div>
 
         <div class="about-summary">
           <ul>
-            <li>다양한 도메인 — 임베디드, 검색, 커머스, 핀테크, 클라우드, AI</li>
-            <li>글로벌 + 한국 — Google 13년(미국) + Banksalad / MegazoneCloud / KAIST(한국)</li>
-            <li>0에서 스케일까지 — App Indexing 데모에서 50명 조직, Banksalad VPE(40+명)</li>
-            <li>교육과 나눔 — KAIST 겸임교수, 온라인 강의, 멘토링</li>
+            <li>임베디드, 검색, 커머스, 핀테크, 클라우드, 산업 AI</li>
+            <li>실리콘밸리 13년, 한국에서의 그 앞뒤</li>
+            <li>엔지니어, 매니저, VP, CTO, 자문으로 옮겨 다닌 자리들</li>
+            <li>잘 풀린 프로젝트, 자연스레 접힌 프로젝트</li>
+            <li>여전히 배우는 자리에서, 가끔 먼저 본 것을 건넵니다.</li>
           </ul>
         </div>
 

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -6,34 +6,34 @@ const highlights = await getSeriesHighlights('ko');
 
 const jsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'ProfessionalService',
-  name: 'Ieum Tech',
-  url: 'https://ieumtech.net',
-  description: '정채상은 기술과 사람을 잇습니다.',
-  founder: {
-    '@type': 'Person',
-    name: '정채상',
-    jobTitle: '대표',
-    sameAs: 'https://linkedin.com/in/chaesang',
-  },
-  contactPoint: {
-    '@type': 'ContactPoint',
-    email: 'hello@ieumtech.net',
-  },
+  '@type': 'Person',
+  name: '정채상',
+  alternateName: 'Chaesang Jung',
+  url: 'https://ieumtech.net/ko/',
+  sameAs: 'https://linkedin.com/in/chaesang',
+  description: '한국과 실리콘밸리를 오가며 IT 현장에서 지내온 시간을 여기에 모아 둡니다.',
 };
 ---
 <Base
-  title="정채상 — 기술과 사람을 잇는 일 | 이음 테크"
-  description="기술은 사람 사이를 지날 때 비로소 깊어집니다. 혼자 고민하던 것들, 같이 생각을 나눕니다. 정채상, 이음 테크."
-  ogTitle="기술과 사람을 잇는 일 | 정채상"
-  ogDescription="혼자 고민하던 것들, 같이 생각을 나눕니다."
+  title="정채상 · Chaesang Jung — 이음"
+  description="한국과 실리콘밸리를 오가며 IT 현장에서 지내왔습니다. 지나온 자리들과 쌓인 배움을 여기에 모아 둡니다."
+  ogTitle="정채상 · Chaesang Jung"
+  ogDescription="한국과 실리콘밸리를 오가며 IT 현장에서 지내온 시간을 모아 두는 자리."
   lang="ko"
   path="/ko/"
-  ogType="website"
+  ogType="profile"
   jsonLd={jsonLd}
   altLangPath="/"
 >
   <style slot="head" is:inline>
+    .hero-inner { padding: 64px 24px 48px; max-width: 640px; margin: 0 auto; }
+    .hero-profile { margin-bottom: 20px; }
+    .hero-profile img { border-radius: 50%; width: 96px; height: 96px; object-fit: cover; }
+    .hero-name { font-size: 1.75rem; font-weight: 600; margin: 0 0 4px; color: var(--color-text); }
+    .hero-name-en { font-size: 0.9375rem; color: var(--color-muted); margin: 0 0 28px; }
+    .hero-intro p { font-size: 1.0625rem; line-height: 1.8; color: var(--color-text); margin: 0 0 10px; }
+    .hero-intro p:last-child { margin-bottom: 0; }
+
     .recent-writing { padding: 48px 0; border-top: 1px solid var(--color-border); }
     .recent-writing-header { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 24px; }
     .recent-writing-header h2 { margin: 0; font-size: 1.25rem; }
@@ -48,69 +48,24 @@ const jsonLd = {
     .recent-writing-desc { font-size: 0.875rem; color: var(--color-muted); margin: 6px 0 10px; line-height: 1.6; }
     .recent-writing-latest { font-size: 0.9375rem; color: var(--color-text); text-decoration: none; display: inline-block; }
     .recent-writing-latest:hover { color: var(--color-accent); }
-    .highlights-grid { display: flex; flex-direction: column; gap: 14px; }
-    .highlight-card { text-align: center; }
-    .highlight-text { font-size: 0.9375rem; font-weight: 500; color: var(--color-text); line-height: 1.5; }
-    .service-card.audience-card { display: flex; align-items: baseline; justify-content: space-between; gap: 24px; padding: 18px 24px; }
-    .service-card.audience-card h3 { flex-shrink: 0; margin-bottom: 0; }
-    .service-card.audience-card p { margin: 0; text-align: right; }
-    @media (max-width: 480px) {
-      .service-card.audience-card { flex-direction: column; align-items: flex-start; gap: 6px; }
-      .service-card.audience-card h3 { min-width: auto; }
-    }
   </style>
 
   <section class="hero" id="home">
     <div class="hero-inner">
-      <p class="hero-sublabel">개발자 정채상이 꾸준히 이어가는 일들</p>
-      <div class="connecting-list">
-        <h1 class="connecting-item">아이디어와 기술을 <span class="connecting-word">이음</span>.</h1>
-        <p class="connecting-item">사람과 사람, 세대와 세대, 앞날을 <span class="connecting-word">이음</span>.</p>
+      <div class="hero-profile">
+        <img src="/profile.jpg" alt="정채상" width="96" height="96" loading="lazy" />
       </div>
-      <p class="hero-sub">혼자 고민하던 것들 — 기술 방향, 팀 운영, 커리어의 다음 걸음.<br />같이 생각을 나눕니다.</p>
-      <p class="hero-vision">기술은 사람 사이를 지날 때 비로소 깊어집니다.</p>
+      <h1 class="hero-name">정채상</h1>
+      <p class="hero-name-en">Chaesang Jung</p>
+      <div class="hero-intro">
+        <p>한국과 실리콘밸리를 오가며, IT 현장에서 지내왔습니다.</p>
+        <p>30년 가까이 격변의 한복판을 지나오며 사람과 기술 사이를 이어 왔고,</p>
+        <p>그 동안 쌓인 배움과 경험을 여기에 모아 두고 있습니다.</p>
+      </div>
     </div>
   </section>
 
   <main>
-    <div class="highlights">
-      <div class="highlights-inner">
-        <div class="highlights-grid">
-          <div class="highlight-card"><div class="highlight-text">IT 현장 30년</div></div>
-          <div class="highlight-card"><div class="highlight-text">구글 13년</div></div>
-          <div class="highlight-card"><div class="highlight-text">수십 명 팀을 함께 이끈 경험</div></div>
-          <div class="highlight-card"><div class="highlight-text">펌웨어에서 AI까지, 엔지니어에서 경영까지</div></div>
-        </div>
-      </div>
-    </div>
-
-    <div class="container">
-      <section id="services" style="border-top: 1px solid var(--color-border); margin-top: 0;">
-        <h2>지나온 곳들</h2>
-        <p style="font-size: 0.9375rem; color: var(--color-muted); font-weight: 300; line-height: 1.8; margin-bottom: 28px;">
-          셋톱박스 펌웨어를 짜던 시절부터, 검색 엔진의 결과를 한 줄씩 다듬던 시절, 앱 생태계를 만들던 시절, 결제 시스템을 혼자 붙이던 시절, 클라우드 비용을 깎던 시절, AI가 공장의 온도를 예측하던 시절까지.<br /><br />
-          엔지니어로, 매니저로, VP로, CTO로, 자문으로 — 역할이 바뀔 때마다 보이는 것이 달랐습니다.
-        </p>
-
-        <h2>함께하고 싶은 사람들</h2>
-        <div class="services-grid" style="grid-template-columns: 1fr;">
-          <div class="service-card audience-card"><h3>처음 매니저가 된 분</h3><p>아무도 다음 길을 알려주지 않을 때.</p></div>
-          <div class="service-card audience-card"><h3>다음 벽 앞에 선 리더</h3><p>성장통이 더 어려운 질문으로 바뀔 때.</p></div>
-          <div class="service-card audience-card"><h3>실리콘밸리와 한국 사이</h3><p>양쪽을 이어줄 누군가 필요할 때.</p></div>
-        </div>
-        <p style="font-size: 0.875rem; color: var(--color-muted); font-weight: 400; margin-top: 16px; text-align: center;">딱 맞지 않아도 괜찮습니다. 좋은 질문이 있다면, 그걸로 충분합니다.</p>
-
-        <h2 style="margin-top: 32px;">함께할 수 있는 일들</h2>
-        <div class="services-grid" style="grid-template-columns: 1fr;">
-          <div class="service-card audience-card"><h3>강의</h3><p>KAIST DFMBA — 인공지능과 추천시스템</p></div>
-          <div class="service-card audience-card"><h3>멘토링</h3><p>1:1 멘토링, Kernel360</p></div>
-          <div class="service-card audience-card"><h3>강연</h3><p>강연, 인터뷰, 팟캐스트</p></div>
-          <div class="service-card audience-card"><h3>온라인 강의</h3><p>Inflearn, Class101, FastCampus, 한빛N</p></div>
-          <div class="service-card audience-card"><h3>글</h3><p>Brunch · NIA 월간 칼럼</p></div>
-        </div>
-      </section>
-    </div>
-
     {highlights.length > 0 && (
       <section class="recent-writing">
         <div class="container">
@@ -140,22 +95,6 @@ const jsonLd = {
         </div>
       </section>
     )}
-
-    <section id="founder" class="about-section">
-      <div class="about-inner">
-        <div class="about-profile">
-          <div class="profile-avatar"><img src="/profile.jpg" alt="정채상" width="96" height="96" loading="lazy" /></div>
-          <div>
-            <h2 class="profile-name">정채상</h2>
-            <p class="profile-secondary-name">Chaesang Jung</p>
-            <p class="profile-headline">기술 곁에는 늘 사람이 있었습니다. 어떤 이야기는 한참 뒤에야 비로소 이해되었고, 그 길을 조금 앞당겨 보려 합니다.</p>
-          </div>
-        </div>
-        <div style="margin-top: 24px;">
-          <a href="/ko/about" class="btn btn-outline btn-sm">정채상 더 알아보기 →</a>
-        </div>
-      </div>
-    </section>
 
     <section class="cta-section" id="contact" aria-labelledby="cta-heading">
       <div class="cta-inner">


### PR DESCRIPTION
## Summary
Phase 4 카피 결정사항과 Phase 2 네비 재편을 홈·About·공통 컴포넌트에 적용합니다. 구조 변경 시리즈의 첫 번째 PR.

## Changes

### Home (`/ko/`, `/`)
- 새 Hero: 이름 + 사진 + 3줄 소개 (Voice Guide 톤)
- 판매 성 섹션 전면 제거: Where I've Been · Who I'm Here For · Ways We Can Work Together · Founder 블록
- 유지: Writing 시리즈 위젯, soft-invite CTA
- JSON-LD: `ProfessionalService` (자기선언) → `Person`

### About (`/ko/about`, `/about`)
- 헤드라인: "기술이 지나온 자리에 늘 사람이 있었습니다." / "Behind the technology, there were always people."
- Highlights 재구성: 5줄, 접힌 프로젝트 포함 (voice-guide 5계 5번)
- **타임라인·특허·강의 리스트는 이번 PR에서 유지** — PR 3에서 /companies, /talks로 이관 예정

### Navigation
- Header/Footer의 Contact / 문의 링크 제거
- Footer는 Email 직링크로 대체
- /contact 별도 페이지는 원래 없음. #contact 앵커만 남음 (홈 CTA 블록)

## Scope boundary
- PR 2: `/portfolio` → `/projects` 리네임
- PR 3: `/companies`, `/talks` 페이지 신설 + About 타임라인·특허·강의 리스트 이관

## Test plan
- [ ] `npm run build` 통과 (54 pages)
- [ ] `/`, `/about`, `/ko/`, `/ko/about`, `/ko/writing` 모두 응답
- [ ] 헤더에 Contact 메뉴 없음
- [ ] Hero에 이름·사진이 가운데 보이고 3줄 소개가 아래

🤖 Generated with [Claude Code](https://claude.com/claude-code)