### PR TITLE
Add Medium link to site footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -18,6 +18,7 @@ const homePath = localizedPath('/', lang);
       <a href={localizedPath('/contact', lang)}>{lang === 'ko' ? '연락하기' : 'Contact'}</a>
       <a href="https://linkedin.com/in/chaesang" target="_blank" rel="noopener noreferrer">LinkedIn</a>
       <a href="https://brunch.co.kr/@chaesang" target="_blank" rel="noopener noreferrer">Brunch</a>
+      <a href="https://chaesangjung.medium.com/" target="_blank" rel="noopener noreferrer">Medium</a>
     </nav>
     <p class="footer-copy">{t('footer.copy')}</p>
   </div>


### PR DESCRIPTION
Closes #53

Adds a Medium link in the global footer next to Brunch, using the same external-link pattern. Single 1-line change in Footer.astro (shared by EN/KO via lang prop).